### PR TITLE
Run workflow only for the master branch

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,6 +1,7 @@
 name: Build and Deploy Storybook
 on:
-  [push]
+  push:
+    branches: [ master ]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I recently noticed that a push to any branch was triggering the workflow which isn't our intended use case, hence this fix.