### PR TITLE
Import Bootstrap transitions

### DIFF
--- a/dist/bootstrap-generic.css
+++ b/dist/bootstrap-generic.css
@@ -3479,6 +3479,43 @@ textarea.form-control-lg {
   border-radius: 0;
 }
 
+.fade {
+  transition: opacity 0.15s linear;
+}
+@media (prefers-reduced-motion: reduce) {
+  .fade {
+    transition: none;
+  }
+}
+.fade:not(.show) {
+  opacity: 0;
+}
+
+.collapse:not(.show) {
+  display: none;
+}
+
+.collapsing {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.35s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .collapsing {
+    transition: none;
+  }
+}
+.collapsing.collapse-horizontal {
+  width: 0;
+  height: auto;
+  transition: width 0.35s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .collapsing.collapse-horizontal {
+    transition: none;
+  }
+}
+
 .dropup,
 .dropend,
 .dropdown,

--- a/dist/bootstrap-mb.css
+++ b/dist/bootstrap-mb.css
@@ -3063,6 +3063,40 @@ a > .bs code {
   font-size: 0.875rem;
   border-radius: 0;
 }
+.bs .fade {
+  transition: opacity 0.15s linear;
+}
+@media (prefers-reduced-motion: reduce) {
+  .bs .fade {
+    transition: none;
+  }
+}
+.bs .fade:not(.show) {
+  opacity: 0;
+}
+.bs .collapse:not(.show) {
+  display: none;
+}
+.bs .collapsing {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.35s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .bs .collapsing {
+    transition: none;
+  }
+}
+.bs .collapsing.collapse-horizontal {
+  width: 0;
+  height: auto;
+  transition: width 0.35s ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .bs .collapsing.collapse-horizontal {
+    transition: none;
+  }
+}
 .bs .dropup,
 .bs .dropend,
 .bs .dropdown,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metabrainz/design-system",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Design system of MetaBrainz",
   "main": "components/index.js",
   "directories": {

--- a/scss/bootstrap-generic.scss
+++ b/scss/bootstrap-generic.scss
@@ -11,7 +11,7 @@
 @import "../node_modules/bootstrap/scss/tables";
 @import "../node_modules/bootstrap/scss/forms";
 @import "../node_modules/bootstrap/scss/buttons";
-// @import "../node_modules/bootstrap/scss/transitions";
+@import "../node_modules/bootstrap/scss/transitions";
 @import "../node_modules/bootstrap/scss/dropdown";
 //@import "../node_modules/bootstrap/scss/button-group";
 @import "../node_modules/bootstrap/scss/nav";

--- a/scss/bootstrap-mb.scss
+++ b/scss/bootstrap-mb.scss
@@ -19,7 +19,7 @@
     @import "../node_modules/bootstrap/scss/tables";
     @import "../node_modules/bootstrap/scss/forms";
     @import "../node_modules/bootstrap/scss/buttons";
-    // @import "../node_modules/bootstrap/scss/transitions";
+    @import "../node_modules/bootstrap/scss/transitions";
     @import "../node_modules/bootstrap/scss/dropdown";
     //@import "../node_modules/bootstrap/scss/button-group";
     @import "../node_modules/bootstrap/scss/nav";


### PR DESCRIPTION
- While fiddling with the Navbar in projects, we realized that the CSS for collapse isn't included. This PR imports the Bootstrap transitions to allow for the same.