### PR TITLE
Publish logos

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -39,7 +39,8 @@ assets/
 scss/
 
 # BRAND
-brand/
+brand/icons/
+brand/logos/development/
 
 # DOCUMENTATION ASSETS
 documentation/

--- a/.npmignore
+++ b/.npmignore
@@ -44,5 +44,3 @@ brand/logos/development/
 
 # DOCUMENTATION ASSETS
 documentation/
-
-


### PR DESCRIPTION
https://github.com/metabrainz/musicbrainz-server/pull/2439 is copying a bunch of logo assets into musicbrainz-server, but I think they should just be published with design-system.  I imagine other projects will find them useful too.

I've left brand/icons/ npmignored for now until we have a use for it, and brand/logos/development/ too, which is only useful for development and historical purposes.